### PR TITLE
Support 'Load More' for the NotificationDrawer

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,7 @@
         "Core.NotificationMenu"
     ],
     "dependencies": {
-        "carwow/elm-theme": "3.0.0 <= v < 4.0.0",
+        "carwow/elm-theme": "4.0.0 <= v < 5.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",


### PR DESCRIPTION
Allow the NotificationDrawer to request more data from the paginated endpoint until the final request.