### PR TITLE
Add notification menu tracking

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,7 @@
         "Core.NotificationMenu"
     ],
     "dependencies": {
-        "carwow/elm-theme": "4.0.0 <= v < 5.0.0",
+        "carwow/elm-theme": "4.0.2 <= v < 5.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",

--- a/src/Core/NotificationMenu.elm
+++ b/src/Core/NotificationMenu.elm
@@ -9,8 +9,8 @@ module Core.NotificationMenu exposing (Msg(UpdateBadge), init, view, update, Mod
 
 -}
 
-import Html exposing (text, span, label, i, Html, a)
-import Html.Attributes exposing (for, href, attribute)
+import Html exposing (text, span, label, i, Html)
+import Html.Attributes exposing (for, attribute)
 import Html.Events exposing (onClick)
 import Svg exposing (text)
 import Svg.Attributes exposing (class)

--- a/src/Core/NotificationMenu.elm
+++ b/src/Core/NotificationMenu.elm
@@ -9,8 +9,8 @@ module Core.NotificationMenu exposing (Msg(UpdateBadge), init, view, update, Mod
 
 -}
 
-import Html exposing (text, span, label, i, Html)
-import Html.Attributes exposing (for)
+import Html exposing (text, span, label, i, Html, a)
+import Html.Attributes exposing (for, href, attribute)
 import Html.Events exposing (onClick)
 import Svg exposing (text)
 import Svg.Attributes exposing (class)
@@ -69,14 +69,23 @@ update msg model =
 -}
 view : Model -> Html Msg
 view model =
-    label
-        [ class "main-header-menu-link main-header-menu-link--extra-padded"
-        , for "notifications-drawer-open"
-        , onClick ClearBadge
-        ]
-        [ badgeView model.unseenCount
-        , i [ class "icon" ] [ icon "bell" { size = "small", colour = "white", colouring = "outline" } ]
-        ]
+    let
+        unseenCount =
+            (toString (Maybe.withDefault 0 model.unseenCount))
+    in
+        label
+            [ class "main-header-menu-link main-header-menu-link--extra-padded"
+            , for "notifications-drawer-open"
+            , onClick ClearBadge
+            , attribute "data-interaction-section" "notification menu"
+            , attribute "data-interaction-type" "open modal"
+            , attribute "data-unseen-count" unseenCount
+            ]
+            [ badgeView model.unseenCount
+            , i
+                [ class "icon icon--notification" ]
+                [ icon "bell" { size = "small", colour = "white", colouring = "outline" } ]
+            ]
 
 
 badgeView : Maybe Int -> Html Msg


### PR DESCRIPTION
Then a click on the icon occurs it doesn't bubble up the event so gtm doesn't track it. One solution I found was to add `pointer-events: none` to the icon so the click event is registered on the parent (that's the label contianing the data attributes in this case). That's the simple thing I could think to make tracking work without big changes.
Change on theme: https://github.com/carwow/carwow-theme/pull/737/files