### PR TITLE
UAS 17 - Make preselection in model menu

### DIFF
--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -180,11 +180,14 @@ update msg model =
                 newModel = { model | state = MakeSelection sortedFilteredResponse }
             in
                 case model.preselectedMakeSlug of
-                    Nothing -> ( newModel, Cmd.none )
+                    Nothing ->
+                        ( newModel, Cmd.none )
                     Just preselected ->
                         case make of
-                            Nothing -> ( newModel, Cmd.none )
-                            Just make -> update (MakeSelected make) newModel
+                            Nothing ->
+                                ( newModel, Cmd.none )
+                            Just make ->
+                                update (MakeSelected make) newModel
 
         ModelsResponse response ->
             let

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -195,17 +195,8 @@ update msg model =
                 newModel =
                     { model | state = MakeSelection sortedFilteredResponse }
             in
-                case model.preselectedMakeSlug of
-                    Nothing ->
-                        ( newModel, Cmd.none )
-
-                    Just preselected ->
-                        case make of
-                            Nothing ->
-                                ( newModel, Cmd.none )
-
-                            Just make ->
-                                update (MakeSelected make) newModel
+                Maybe.map2 (\preselected make -> (update (MakeSelected make) newModel)) model.preselectedMakeSlug make
+                    |> Maybe.withDefault ( newModel, Cmd.none )
 
         ModelsResponse response ->
             let

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -228,7 +228,7 @@ update msg model =
                 newState =
                     MakeSelection RemoteData.Loading
             in
-                ( { model | state = newState }, getAvailableMakes (makesApiUrl model.apiEndpointUrl) )
+                ( { model | state = newState, preselectedMakeSlug = Nothing }, getAvailableMakes (makesApiUrl model.apiEndpointUrl) )
 
         UrlChange location ->
             let

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -139,8 +139,8 @@ update msg model =
                     CarwowTheme.Modal.update inner model.modal
 
                 navigationCmd = if newModal.isOpen == False then
-                        currentUrlWithoutHash(model.location)
-                            |> currentUrlWithoutMake
+                        locationWithoutHash(model.location)
+                            |> locationWithoutMake
                             |> Erl.toString
                             |> Navigation.modifyUrl
                     else
@@ -230,7 +230,7 @@ update msg model =
 
                 commands = Cmd.batch[
                     getAvailableMakes (makesApiUrl model.apiEndpointUrl)
-                    , currentUrlWithoutMake(model.location) |> Erl.toString |> Navigation.modifyUrl
+                    , locationWithoutMake(model.location) |> Erl.toString |> Navigation.modifyUrl
                     ]
             in
                 ( { model | state = newState, preselectedMakeSlug = Nothing }, commands )
@@ -279,12 +279,12 @@ findPreselectedMake slug makes =
                  |> Maybe.andThen (List.filter (\x -> x.slug == slug) >> List.head)
 
 
-currentUrlWithoutMake : Url -> Url
-currentUrlWithoutMake url =
+locationWithoutMake : Url -> Url
+locationWithoutMake url =
     Erl.removeQuery "make" url
 
-currentUrlWithoutHash : Url -> Url
-currentUrlWithoutHash url =
+locationWithoutHash : Url -> Url
+locationWithoutHash url =
     { url | hash = "" }
 
 {-| A view representing the list of Makes/Models

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -21,6 +21,7 @@ import Core.Data.Make exposing (..)
 import Core.Data.Model exposing (..)
 import Navigation
 
+
 {-| The state of the model
 -}
 type State
@@ -34,7 +35,8 @@ modal - The modal component that the MakeModelMenu will use
 apiEndpointUrl - The url of the API endpoint to retrieve the Make/Model data from
 apiFilterField - The filter field used in the API request
 baseLinkUrl - The path to re-direct to once the Make Model has been selected
-redirectUrl - The url that the Menu should re-direct to once the Make & Model has been selected, e.g https://quotes.carwow.co.uk/
+redirectUrl - The url that the Menu should re-direct to once the Make & Model has been selected, e.g <https://quotes.carwow.co.uk/>
+
 -}
 type alias Model =
     { state : State
@@ -42,7 +44,7 @@ type alias Model =
     , apiEndpointUrl : Erl.Url
     , apiFilterField : String
     , baseLinkUrl : Erl.Url
-    , redirectUrl: String
+    , redirectUrl : String
     , preselectedMakeSlug : Maybe String
     , location : Url
     }
@@ -55,6 +57,7 @@ MakesResponse - A response is received from the Makes endpoint
 ModelsResponse -A response is received from the Models endpoint
 ModalMsg - A message is received by the underlying Modal component
 UrlChange - A message is received when the address bar changes
+
 -}
 type Msg
     = MakeSelected Core.Data.Make.Make
@@ -72,7 +75,7 @@ type alias Flags =
     , apiEndpointUrl : String
     , apiFilterField : String
     , baseLinkUrl : String
-    , redirectUrl: String
+    , redirectUrl : String
     }
 
 
@@ -119,6 +122,7 @@ init flags location =
             case mapUrlToModalOpen url of
                 True ->
                     getAvailableMakes (makesApiUrl model.apiEndpointUrl)
+
                 False ->
                     Cmd.none
 
@@ -138,8 +142,9 @@ update msg model =
                 ( newModal, modalUpdateCmd ) =
                     CarwowTheme.Modal.update inner model.modal
 
-                navigationCmd = if newModal.isOpen == False then
-                        locationWithoutHash(model.location)
+                navigationCmd =
+                    if newModal.isOpen == False then
+                        locationWithoutHash (model.location)
                             |> locationWithoutMake
                             |> Erl.toString
                             |> Navigation.newUrl
@@ -184,16 +189,21 @@ update msg model =
                         _ ->
                             ( RemoteData.Loading, Cmd.none )
 
-                make = findPreselectedMake model.preselectedMakeSlug sortedFilteredResponse
-                newModel = { model | state = MakeSelection sortedFilteredResponse }
+                make =
+                    findPreselectedMake model.preselectedMakeSlug sortedFilteredResponse
+
+                newModel =
+                    { model | state = MakeSelection sortedFilteredResponse }
             in
                 case model.preselectedMakeSlug of
                     Nothing ->
                         ( newModel, Cmd.none )
+
                     Just preselected ->
                         case make of
                             Nothing ->
                                 ( newModel, Cmd.none )
+
                             Just make ->
                                 update (MakeSelected make) newModel
 
@@ -228,10 +238,11 @@ update msg model =
                 newState =
                     MakeSelection RemoteData.Loading
 
-                commands = Cmd.batch[
-                    getAvailableMakes (makesApiUrl model.apiEndpointUrl)
-                    , locationWithoutMake(model.location) |> Erl.toString |> Navigation.newUrl
-                    ]
+                commands =
+                    Cmd.batch
+                        [ getAvailableMakes (makesApiUrl model.apiEndpointUrl)
+                        , locationWithoutMake (model.location) |> Erl.toString |> Navigation.newUrl
+                        ]
             in
                 ( { model | state = newState, preselectedMakeSlug = Nothing }, commands )
 
@@ -241,13 +252,15 @@ update msg model =
                     case mapUrlToModalOpen (Erl.parse location.href) of
                         True ->
                             CarwowTheme.Modal.update (CarwowTheme.Modal.SwitchModal True) model.modal
+
                         _ ->
-                            (model.modal, Cmd.none)
+                            ( model.modal, Cmd.none )
 
                 ( newModel, makeModelMenuCmd ) =
                     case mapUrlToModalOpen (Erl.parse location.href) of
                         True ->
                             ( { model | state = (MakeSelection RemoteData.Loading) }, getAvailableMakes (makesApiUrl model.apiEndpointUrl) )
+
                         _ ->
                             ( model, Cmd.none )
 
@@ -276,19 +289,24 @@ processRemoteData field items =
 findPreselectedMake : Maybe String -> WebData (List Make) -> Maybe Make
 findPreselectedMake slug makes =
     case slug of
-        Nothing -> Nothing
+        Nothing ->
+            Nothing
+
         Just slug ->
-           makes |> RemoteData.toMaybe
-                 |> Maybe.andThen (List.filter (\x -> x.slug == slug) >> List.head)
+            makes
+                |> RemoteData.toMaybe
+                |> Maybe.andThen (List.filter (\x -> x.slug == slug) >> List.head)
 
 
 locationWithoutMake : Url -> Url
 locationWithoutMake url =
     Erl.removeQuery "make" url
 
+
 locationWithoutHash : Url -> Url
 locationWithoutHash url =
     { url | hash = "" }
+
 
 {-| A view representing the list of Makes/Models
 -}
@@ -317,13 +335,15 @@ modalMakesView makesRemoteData =
     let
         makeView =
             (\make ->
-                [ a [ href "javascript:void(0)"
-                , class "makes-models-menu__link makes-models-menu__make"
-                , attribute "data-interaction-element" "Choose make"
-                , attribute "data-interaction-section" "make-models modal"
-                , attribute "data-interaction-type" "select make"
-                , Html.Events.onClick (MakeSelected make) ]
-                [ makeIcon (String.toLower make.slug) Nothing, div [ class "makes-models-menu__make" ] [ text make.name ] ]
+                [ a
+                    [ href "javascript:void(0)"
+                    , class "makes-models-menu__link makes-models-menu__make"
+                    , attribute "data-interaction-element" "Choose make"
+                    , attribute "data-interaction-section" "make-models modal"
+                    , attribute "data-interaction-type" "select make"
+                    , Html.Events.onClick (MakeSelected make)
+                    ]
+                    [ makeIcon (String.toLower make.slug) Nothing, div [ class "makes-models-menu__make" ] [ text make.name ] ]
                 ]
             )
     in
@@ -339,7 +359,7 @@ modalModelsView make redirectUrl baseLinkUrl modelsRemoteData =
             (\model ->
                 redirectUrl
                     |> Erl.parse
-                    |> Erl.appendPathSegments (Erl.toString(baseLinkUrl) |> String.split "/")
+                    |> Erl.appendPathSegments (Erl.toString (baseLinkUrl) |> String.split "/")
                     |> Erl.addQuery "make" make.slug
                     |> Erl.addQuery "model" model.slug
                     |> Erl.toString
@@ -347,12 +367,14 @@ modalModelsView make redirectUrl baseLinkUrl modelsRemoteData =
 
         modelView =
             (\model ->
-                [ a [ href (makeModelUrl model)
-                , class "makes-models-menu__link makes-models-menu__model"
-                , attribute "data-interaction-element" "Choose model"
-                , attribute "data-interaction-section" "make-models modal"
-                , attribute "data-interaction-type" "select model" ]
-                [ text model.name ]
+                [ a
+                    [ href (makeModelUrl model)
+                    , class "makes-models-menu__link makes-models-menu__model"
+                    , attribute "data-interaction-element" "Choose model"
+                    , attribute "data-interaction-section" "make-models modal"
+                    , attribute "data-interaction-type" "select model"
+                    ]
+                    [ text model.name ]
                 ]
             )
     in

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -116,12 +116,11 @@ init flags location =
             Model state modal apiEndpointUrl flags.apiFilterField baseLinkUrl flags.redirectUrl preselectedMakeSlug
 
         getMakesCmd =
-            getAvailableMakes (makesApiUrl model.apiEndpointUrl)
---            case mapUrlToModalOpen url of
---                True ->
---                    getAvailableMakes (makesApiUrl model.apiEndpointUrl)
---                False ->
---                    Cmd.none
+            case mapUrlToModalOpen url of
+                True ->
+                    getAvailableMakes (makesApiUrl model.apiEndpointUrl)
+                False ->
+                    Cmd.none
 
         commands =
             Cmd.batch [ getMakesCmd ]

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -109,8 +109,7 @@ init flags location =
             MakeSelection RemoteData.Loading
 
         preselectedMakeSlug =
-            Erl.getQueryValuesForKey "make" url
-                |> List.head
+            Erl.getQueryValuesForKey "make" url |> List.head
 
         model =
             Model state modal apiEndpointUrl flags.apiFilterField baseLinkUrl flags.redirectUrl preselectedMakeSlug

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -109,7 +109,8 @@ init flags location =
             MakeSelection RemoteData.Loading
 
         preselectedMakeSlug =
-            Just "Ford"
+            Erl.getQueryValuesForKey "make" url
+                |> List.head
 
         model =
             Model state modal apiEndpointUrl flags.apiFilterField baseLinkUrl flags.redirectUrl preselectedMakeSlug

--- a/src/Core/MakeModelMenu.elm
+++ b/src/Core/MakeModelMenu.elm
@@ -142,7 +142,7 @@ update msg model =
                         locationWithoutHash(model.location)
                             |> locationWithoutMake
                             |> Erl.toString
-                            |> Navigation.modifyUrl
+                            |> Navigation.newUrl
                     else
                         Cmd.none
 
@@ -230,7 +230,7 @@ update msg model =
 
                 commands = Cmd.batch[
                     getAvailableMakes (makesApiUrl model.apiEndpointUrl)
-                    , locationWithoutMake(model.location) |> Erl.toString |> Navigation.modifyUrl
+                    , locationWithoutMake(model.location) |> Erl.toString |> Navigation.newUrl
                     ]
             in
                 ( { model | state = newState, preselectedMakeSlug = Nothing }, commands )
@@ -250,8 +250,11 @@ update msg model =
                             ( { model | state = (MakeSelection RemoteData.Loading) }, getAvailableMakes (makesApiUrl model.apiEndpointUrl) )
                         _ ->
                             ( model, Cmd.none )
+
+                preselectedMakeSlug =
+                    Erl.parse location.href |> Erl.getQueryValuesForKey "make" |> List.head
             in
-                ( { newModel | modal = newModal, location = (Erl.parse location.href) }, Cmd.batch [ Cmd.map ModalMsg modalUpdateCmd, makeModelMenuCmd ] )
+                ( { newModel | modal = newModal, location = (Erl.parse location.href), preselectedMakeSlug = preselectedMakeSlug }, Cmd.batch [ Cmd.map ModalMsg modalUpdateCmd, makeModelMenuCmd ] )
 
 
 {-| Process the Make/Model data retrieved from research site


### PR DESCRIPTION
- Allows a make to be preselected based on make query param
- Modal back button clears make from URL
- Gracefully handles incorrect Make slugs (defaulting to Make selection)
- Escape, close and back all modify browser history to ensure back button reopens model